### PR TITLE
revamp home screen with profile, account cards, and navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,16 @@
-import 'package:fintech_investor_app/screens/activity_screen.dart';
-import 'package:fintech_investor_app/screens/discover_screen.dart';
-import 'package:fintech_investor_app/screens/home_screen.dart';
-import 'package:fintech_investor_app/screens/move_screen.dart';
-import 'package:fintech_investor_app/widgets/bottom_nav_bar.dart';
+// lib/main.dart
 import 'package:flutter/material.dart';
+
+// Screens
+import 'screens/home_screen.dart';
+import 'screens/discover_screen.dart';
+import 'screens/move_screen.dart';
+import 'screens/activity_screen.dart';
+import 'screens/notifications_page.dart';
+import 'screens/account_screen.dart';
+
+// Widgets
+import 'widgets/bottom_nav_bar.dart';
 
 void main() {
   runApp(const MyApp());
@@ -11,15 +18,19 @@ void main() {
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Invester',
+      title: 'Flutter Investor',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
+      // Named routes for direct navigation
+      routes: {
+        NotificationsPage.routeName: (_) => const NotificationsPage(),
+        AccountScreen.routeName:     (_) => const AccountScreen(),
+      },
       home: const MainWrapper(),
     );
   }
@@ -27,15 +38,15 @@ class MyApp extends StatelessWidget {
 
 class MainWrapper extends StatefulWidget {
   const MainWrapper({super.key});
-
   @override
   State<MainWrapper> createState() => _MainWrapperState();
 }
 
 class _MainWrapperState extends State<MainWrapper> {
-  int _currentIndex = 0; // Start with Home tab selected
+  int _currentIndex = 0; // Start with Home tab
 
-  final List<Widget> _screens = [
+  // The four main tabs
+  static final List<Widget> _screens = [
     const HomeScreen(),
     const DiscoverScreen(),
     MoveScreen(),
@@ -45,18 +56,12 @@ class _MainWrapperState extends State<MainWrapper> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      // Show the selected tab
       body: _screens[_currentIndex],
       bottomNavigationBar: BottomNavBar(
         currentIndex: _currentIndex,
-        onTap: (index) {
-          setState(() {
-            _currentIndex = index;
-          });
-        },
+        onTap: (i) => setState(() => _currentIndex = i),
       ),
     );
   }
 }
-
-
-

--- a/lib/models/accounts.dart
+++ b/lib/models/accounts.dart
@@ -1,53 +1,33 @@
-import 'package:fintech_investor_app/models/open_account.dart';
 import 'package:flutter/material.dart';
 
-class Accounts extends StatefulWidget {
-  @override
-  State<StatefulWidget> createState() => AccountsState();
+/// A simple data model for an account card.
+class AccountItem {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  AccountItem({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
 }
 
-class AccountsState extends State<Accounts> {
-  @override
-  Widget build(BuildContext context) {
-    // TODO: implement build
-    return Container(
-      child: Column(
-        children: <Widget>[
-          Text(
-            "Account",
-            style: Theme.of(context).textTheme.headlineLarge,
-            // style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-          ),
-          Card(
-            child: ListTile(
-              leading: Icon(Icons.savings, color: Color(0xFFE5A4A7)),
-              title: Text("Savings"),
-              subtitle: Text("Balance: \$12345.00"),
-              trailing: Icon(Icons.more_vert),
-              isThreeLine: true,
-            ),
-          ),
-          Card(
-            child: ListTile(
-              leading: Icon(Icons.currency_bitcoin, color: Colors.yellow),
-              title: Text("Bitcoin"),
-              subtitle: Text("Hold: 1.35 bitcoins, value: \$9564.56"),
-              trailing: Icon(Icons.more_vert),
-              isThreeLine: true,
-            ),
-          ),
-          Card(
-            child: ListTile(
-              leading: Icon(Icons.show_chart, color: Colors.green),
-              title: Text("Stock Market"),
-              subtitle: Text("Value: \$954564.56"),
-              trailing: Icon(Icons.more_vert),
-              isThreeLine: true,
-            ),
-          ),
-          OpenAccount(),
-        ],
-      ),
-    );
-  }
-}
+/// Sample accounts to show on HomeScreen
+final List<AccountItem> demoAccounts = [
+  AccountItem(
+    icon: Icons.savings,
+    title: 'Savings',
+    subtitle: 'Balance: \$12,345.00',
+  ),
+  AccountItem(
+    icon: Icons.currency_bitcoin,
+    title: 'Bitcoin',
+    subtitle: 'Hold: 1.35 BTC (\$9,564.56)',
+  ),
+  AccountItem(
+    icon: Icons.show_chart,
+    title: 'Stock Market',
+    subtitle: 'Value: \$954,564.56',
+  ),
+];

--- a/lib/models/advertises.dart
+++ b/lib/models/advertises.dart
@@ -1,9 +1,33 @@
 import 'package:flutter/material.dart';
 
-class Advertises extends StatelessWidget{
-  @override
-  Widget build(BuildContext context) {
-    // TODO: implement build
-    return Text("Advertises.");
-  }
+/// A simple data model for a recommendation card.
+class AdvertiseItem {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  AdvertiseItem({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
 }
+
+/// Sample “Recommended for You” cards
+final List<AdvertiseItem> demoAdvertises = [
+  AdvertiseItem(
+    icon: Icons.trending_up,
+    title: 'Invest in Stocks',
+    subtitle: 'Start with as little as \$50',
+  ),
+  AdvertiseItem(
+    icon: Icons.pie_chart,
+    title: 'Diversify Portfolio',
+    subtitle: 'Balance risk and reward',
+  ),
+  AdvertiseItem(
+    icon: Icons.auto_graph,
+    title: 'Track Crypto',
+    subtitle: 'Stay ahead of the market',
+  ),
+];

--- a/lib/screens/account_screen.dart
+++ b/lib/screens/account_screen.dart
@@ -1,0 +1,37 @@
+// lib/screens/account_screen.dart
+import 'package:flutter/material.dart';
+import 'package:fintech_investor_app/models/accounts.dart';
+
+class AccountScreen extends StatelessWidget {
+  static const routeName = '/account';
+  const AccountScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Account')),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: demoAccounts.length,
+        itemBuilder: (ctx, i) {
+          final acct = demoAccounts[i];
+          return Card(
+            margin: const EdgeInsets.symmetric(vertical: 8),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: ListTile(
+              leading: Icon(acct.icon, size: 32, color: Theme.of(ctx).primaryColor),
+              title: Text(acct.title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
+              subtitle: Text(acct.subtitle),
+              trailing: const Icon(Icons.more_vert),
+              onTap: () {
+                // optionally drill into account details
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,47 +1,90 @@
+// lib/screens/home_screen.dart
+
+import 'package:flutter/material.dart';
 import 'package:fintech_investor_app/models/accounts.dart';
 import 'package:fintech_investor_app/models/advertises.dart';
-import 'package:fintech_investor_app/models/core.dart';
-import 'package:fintech_investor_app/models/notifications.dart';
-import 'package:fintech_investor_app/models/rewards.dart';
-import 'package:flutter/material.dart';
 import 'package:fintech_investor_app/screens/notifications_page.dart';
+import 'package:fintech_investor_app/screens/account_screen.dart';
 
-// Home screen has three parts. Encapsulate them to classes for convenience.
-// 1. App bar.
-// 2. Accounts.
-// 3. Advertises.
-class HomeScreen extends StatefulWidget {
+class HomeScreen extends StatelessWidget {
+  static const routeName = '/home';
   const HomeScreen({super.key});
 
-  @override
-  State<StatefulWidget> createState() => _HomeScreenState();
-}
-
-class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Row(
-          children: [
-            const Text('Home'),
-            IconButton(
-              icon: const Icon(Icons.notifications),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => const NotificationsPage()),
-                );
+        title: const Text('Home'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.notifications),
+            onPressed: () {
+              Navigator.pushNamed(context, NotificationsPage.routeName);
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.person),
+            onPressed: () {
+              Navigator.pushNamed(context, AccountScreen.routeName);
+            },
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // — Greeting / Net-worth preview —
+          Row(
+            children: [
+              CircleAvatar(
+                radius: 24,
+                backgroundImage: AssetImage('assets/images/avatar.png'),
+              ),
+              const SizedBox(width: 12),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: const [
+                  Text('Hello, John!', style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600)),
+                  SizedBox(height: 4),
+                  Text('Net worth: \$1,234,567.89', style: TextStyle(color: Colors.grey)),
+                ],
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 24),
+          const Text('Your Accounts', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          // — Accounts list —
+          ...demoAccounts.map((acct) => Card(
+            margin: const EdgeInsets.symmetric(vertical: 6),
+            child: ListTile(
+              leading: Icon(acct.icon, size: 32, color: Theme.of(context).primaryColor),
+              title: Text(acct.title, style: const TextStyle(fontWeight: FontWeight.w600)),
+              subtitle: Text(acct.subtitle),
+              trailing: const Icon(Icons.more_vert),
+              onTap: () {
+                // optional: deep-link into each account
               },
             ),
-            Rewards(),
-            Core(),
-          ],
-        ),
-      ),
-      body: Column(
-        // Accounts & Advertises.
-        children: [Accounts(), Advertises()],
+          )),
+
+          const SizedBox(height: 24),
+          const Text('Recommended for You', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          // — Recommendation cards —
+          ...demoAdvertises.map((ad) => Card(
+            margin: const EdgeInsets.symmetric(vertical: 6),
+            child: ListTile(
+              leading: Icon(ad.icon, size: 32, color: Theme.of(context).colorScheme.secondary),
+              title: Text(ad.title),
+              subtitle: Text(ad.subtitle),
+              onTap: () {
+                // navigate to more details
+              },
+            ),
+          )),
+        ],
       ),
     );
   }

--- a/lib/screens/notifications_page.dart
+++ b/lib/screens/notifications_page.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 
 class NotificationsPage extends StatelessWidget {
+  static const routeName = '/notifications';
   const NotificationsPage({super.key});
 
   @override

--- a/lib/widgets/text_style.dart
+++ b/lib/widgets/text_style.dart
@@ -7,3 +7,4 @@ class HeadlineTextStyle extends StatelessWidget{
     return Text("Advertises.");
   }
 }
+


### PR DESCRIPTION
This PR overhauls the **Home** tab into a true dashboard and wires up the person-icon to navigate to the user’s **Account** screen. It also:

- Introduces dedicated data models (`AccountItem` & `AdvertiseItem`)  
- Adds sample data in `lib/models/accounts.dart` and `lib/models/advertises.dart`  
- Updates `HomeScreen` UI: greeting row, net-worth preview, “Your Accounts” list, and “Recommended for You” cards  
- Defines `static const routeName` on `HomeScreen`, `NotificationsPage`, and `AccountScreen`  
- Resolves const-constructor errors in `MoveScreen` by switching to a `final` field  
- Registers named routes in `main.dart` for notifications & account pages  
- Ensures all constructors are const-safe or appropriately non-const

---

## 🔄 Changes Overview

### 1. New Data Models
- **`lib/models/accounts.dart`**  
  - Added `AccountItem` class  
  - Defined sample `demoAccounts` list  
- **`lib/models/advertises.dart`**  
  - Added `AdvertiseItem` class  
  - Defined sample `demoAdvertises` list  

### 2. Home Screen UI  
- **`lib/screens/home_screen.dart`**  
  - Added `static const routeName = '/home'`  
  - AppBar now has 🔔 **Notifications** & 👤 **Profile** icons  
  - Body sections:  
  1. Greeting row with avatar + “Hello, John!” + net-worth preview  
  2. **Your Accounts** section using `demoAccounts`  
  3. **Recommended for You** section using `demoAdvertises`  

### 3. Named Routes for Screens  
- **`lib/screens/notifications_page.dart`** → `static const routeName = '/notifications';`  
- **`lib/screens/account_screen.dart`** → `static const routeName = '/account';`  

### 4. MoveScreen Const Fix  
- **`lib/screens/move_screen.dart`**  
  - Removed `const` constructor  
  - Changed `moveItems` to a `final` instance field  
  - Updated parent widget list from `static const` → `static final`  

### 5. Main App Routing  
- **`lib/main.dart`**  
  - Registered named routes for `/notifications` and `/account`  
  - Kept `home:` pointed to `MainWrapper()`  

---

## ⚠️ Breaking / Migration Notes
- **MoveScreen** no longer has a `const` constructor; update any `static const List<Widget>` references to `static final`.  
- Add an `avatar.png` (or swap to a network image) under `assets/images/` and declare it in `pubspec.yaml`.

---

## ✅ How to Test

1. **Clean & run**  
   ```bash
   flutter clean && flutter pub get  
   flutter run -d chrome
   ```
2. **Home Tab**  
   - Verify greeting row with avatar + net-worth.  
   - Confirm “Your Accounts” shows Savings, Bitcoin, Stock Market cards.  
   - Confirm “Recommended for You” shows three recommendation cards.  
3. **Navigation**  
   - Tap 🔔 → opens NotificationsPage.  
   - Tap 👤 → opens AccountScreen.  
   - Bottom-tab nav still works, including Move tab (Deposit, Transfer, etc.).  
4. **Build Errors**  
   - No const-constructor errors.  
   - No missing getters for `demoAccounts` or `demoAdvertises`.
   
   
   
![Screenshot (333)](https://github.com/user-attachments/assets/d73f14ca-b9a9-4304-82d9-e53e940ee0cd)
![Screenshot (334)](https://github.com/user-attachments/assets/21071c07-3bd1-4b6d-b33d-71c34e478c78)
![Screenshot (335)](https://github.com/user-attachments/assets/80a51966-2020-4d05-ab23-b9f80e003459)

